### PR TITLE
Add backend requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This is a simple and responsive ticketing system built with React, Tailwind CSS,
 
   ```
   npm install
+  pip install -r backend/requirements.txt
   ```
 3. Start the dev server:
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+flask
+flask-cors
+flask-sqlalchemy


### PR DESCRIPTION
## Summary
- add a backend requirements.txt for Flask
- include pip install step in README

## Testing
- `npm run build`
- `python3 -m venv venv && source venv/bin/activate && pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68606c06a4bc8322b74fbc99609095c2