### PR TITLE
Improve priority UI and clarify Flask backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a simple and responsive ticketing system built with React, Tailwind CSS,
 - Create, view, edit, and manage support tickets
 - Claim or unclaim tasks (toggles ownership)
 - Inline editing for priority, status, and owner fields
+- Color-coded priority levels (Low, Medium, High, and **Unbreak Immediately**)
 - Dashboard with clickable status filters (Open, Acknowledged, etc.)
 - Individual ticket view pages at `/ticket/:id`
 - Clean and modern UI with Tailwind CSS

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,34 @@
+# Flask Ticketing API
+
+This directory houses the Flask service that powers the ticketing system. It replaces the earlier Express/JSON server with a Python-based backend.
+
+## Tech Stack
+
+- Python 3.10+
+- Flask with CORS support
+- Flask-SQLAlchemy (SQLite database)
+
+## Getting Started
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the API from the project root:
+   ```bash
+   python backend/app.py
+   ```
+   By default the server runs on `http://localhost:5050`.
+
+The first run creates a local `tickets.db` SQLite database.
+
+## Endpoints
+
+- `GET /tickets` — list all tickets
+- `POST /tickets` — create a ticket
+- `PUT /tickets/<id>` — update a ticket
+- `PUT /tickets/<id>/claim` — claim or unclaim a ticket
+- `GET /tickets/owner/<owner>` — list tickets by owner
+
+All responses are in JSON format.
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,17 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useParams, useLocation } from "react-router-dom";
 
+const PRIORITY_OPTIONS = [
+  { value: 0, label: "Low", color: "bg-yellow-500 text-white" },
+  { value: 1, label: "Medium", color: "bg-orange-500 text-white" },
+  { value: 2, label: "High", color: "bg-red-500 text-white" },
+  { value: 3, label: "Unbreak Immediately", color: "bg-purple-600 text-white" },
+];
+
+function priorityInfo(value) {
+  return PRIORITY_OPTIONS.find((opt) => opt.value === parseInt(value)) || PRIORITY_OPTIONS[0];
+}
+
 function useQuery() {
   return new URLSearchParams(useLocation().search);
 }
@@ -26,7 +37,14 @@ function TicketViewPage() {
         <p><strong>Subject:</strong> {ticket.subject}</p>
         <p><strong>Description:</strong> {ticket.description}</p>
         <p><strong>Status:</strong> {ticket.status}</p>
-        <p><strong>Priority:</strong> {ticket.priority}</p>
+        <p>
+          <strong>Priority:</strong>
+          <span
+            className={"ml-2 rounded px-2 py-1 " + priorityInfo(ticket.priority).color}
+          >
+            {priorityInfo(ticket.priority).label}
+          </span>
+        </p>
         <p><strong>Owner:</strong> {ticket.owner}</p>
         <p><strong>Issue Type:</strong> {ticket.issue_type}</p>
         <p><strong>Subcategory:</strong> {ticket.subcategory}</p>
@@ -118,13 +136,19 @@ function TicketList() {
                 </td>
                 <td className="p-2">
                   <select
-                    className="border rounded px-2 py-1"
+                    className={
+                      "border rounded px-2 py-1 " + priorityInfo(ticket.priority).color
+                    }
                     value={ticket.priority}
-                    onChange={(e) => handleInlineUpdate(ticket.id, "priority", parseInt(e.target.value))}
+                    onChange={(e) =>
+                      handleInlineUpdate(ticket.id, "priority", parseInt(e.target.value))
+                    }
                   >
-                    <option value={0}>Low</option>
-                    <option value={1}>Medium</option>
-                    <option value={2}>High</option>
+                    {PRIORITY_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
                   </select>
                 </td>
                 <td className="p-2">
@@ -198,10 +222,17 @@ function NewTicketPage() {
         <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <input name="subject" value={formState.subject} onChange={handleChange} placeholder="Subject" className="input" />
           <input name="owner" value={formState.owner} onChange={handleChange} placeholder="Owner" className="input" />
-          <select name="priority" value={formState.priority} onChange={handleChange} className="input">
-            <option value={0}>Low</option>
-            <option value={1}>Medium</option>
-            <option value={2}>High</option>
+          <select
+            name="priority"
+            value={formState.priority}
+            onChange={handleChange}
+            className={"input " + priorityInfo(formState.priority).color}
+          >
+            {PRIORITY_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
           </select>
           <select name="status" value={formState.status} onChange={handleChange} className="input">
             <option value="open">Open</option>
@@ -271,10 +302,17 @@ function EditTicketPage() {
         <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <input name="subject" value={formState.subject} onChange={handleChange} placeholder="Subject" className="input" />
           <input name="owner" value={formState.owner} onChange={handleChange} placeholder="Owner" className="input" />
-          <select name="priority" value={formState.priority} onChange={handleChange} className="input">
-            <option value={0}>Low</option>
-            <option value={1}>Medium</option>
-            <option value={2}>High</option>
+          <select
+            name="priority"
+            value={formState.priority}
+            onChange={handleChange}
+            className={"input " + priorityInfo(formState.priority).color}
+          >
+            {PRIORITY_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
           </select>
           <select name="status" value={formState.status} onChange={handleChange} className="input">
             <option value="open">Open</option>


### PR DESCRIPTION
## Summary
- color-code priority dropdowns with new "Unbreak Immediately" level
- display priority bubble in ticket detail view
- note color-coded priority in main README
- clarify in backend README that Flask replaces the earlier Express server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68606f058ea88322a36a8276cb2f5eb5